### PR TITLE
update: kamal to 1.9.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          gem install kamal -v 1.8.1
+          gem install kamal -v 1.9.0
 
       - name: Turnstyle
         uses: softprops/turnstyle@v1


### PR DESCRIPTION
We want to update to 2.x but according to the guide, the first step is to upgrade to 1.9.x. Let's start with 1.9.0 before going to 1.9.2

https://kamal-deploy.org/docs/upgrading/overview/