### PR TITLE
Fix generate-env.sh script POSIX compatibility

### DIFF
--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Generate environment configuration file from environment variables
 # Usage: ./generate-env-config.sh
@@ -8,8 +8,8 @@ OUTPUT_FILE="packages/rw-app/.dev.vars"
 
 # Function to resolve environment variable or show placeholder
 resolve_env() {
-    local var_name="$1"
-    local value="${!var_name}"
+    var_name="$1"
+    value=$(eval echo "\$$var_name")
     if [ -n "$value" ]; then
         echo "$var_name=$value"
     else


### PR DESCRIPTION
## Summary
- Fixed "Bad substitution" error when running generate-env.sh with sh
- Replaced bash-specific syntax with POSIX-compliant alternatives

## Changes
- Changed shebang from `#\!/bin/bash` to `#\!/bin/sh` for better portability
- Replaced bash indirect variable expansion `${\!var_name}` with POSIX-compliant `eval echo "\$$var_name"`
- Removed `local` keyword which is not guaranteed in POSIX sh

## Test plan
- [x] Run `sh scripts/generate-env.sh` - should complete without errors
- [x] Verify `.dev.vars` file is generated with expected format
- [x] Confirm placeholders are shown for unset environment variables

🤖 Generated with [Claude Code](https://claude.ai/code)