### PR TITLE
fix: remove unnecessary @ts-expect-error comments to resolve lint errors

### DIFF
--- a/packages/rw-app/src/layouts/AppLayout.tsx
+++ b/packages/rw-app/src/layouts/AppLayout.tsx
@@ -21,7 +21,6 @@ export function AppLayout({ children, requestInfo }: LayoutProps) {
           <div
             className={`flex flex-col items-center justify-center w-full mt-16 sm:mt-24`}
           >
-            {/* @ts-expect-error fix react types */}
             {children}
           </div>
         </div>

--- a/packages/rw-app/src/worker.tsx
+++ b/packages/rw-app/src/worker.tsx
@@ -85,7 +85,6 @@ export default defineApp([
       } as User
     }
   },
-  // @ts-expect-error fix document types
   render(Document, [
     layout(AppLayout, [
       route('/', ({ ctx }) => {


### PR DESCRIPTION
## Summary
- Removes redundant `@ts-expect-error` comments from `AppLayout.tsx` and `worker.tsx` files
- Addresses lint errors related to unused or unnecessary TypeScript error suppressions

## Changes

### Code Cleanup
- Deleted `@ts-expect-error` comment above `children` rendering in `AppLayout.tsx`
- Deleted `@ts-expect-error` comment before `render` call in `worker.tsx`

## Test plan
- [x] Verify that the app builds without lint errors
- [x] Confirm no runtime issues arise from removal of these comments
- [x] Run existing tests to ensure no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/89399e64-4d56-4ce1-9a39-3b728ee8f187