### PR TITLE
Configure Renovate to group multiple monorepo packages including Kubb, Turf.js, and Stricli

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,24 @@
       "matchPackagePatterns": ["^@kubb/"],
       "groupName": "kubb monorepo",
       "groupSlug": "kubb-monorepo"
+    },
+    {
+      "description": "Group Turf.js monorepo packages",
+      "matchPackagePatterns": ["^@turf/"],
+      "groupName": "turf monorepo",
+      "groupSlug": "turf-monorepo"
+    },
+    {
+      "description": "Group Stricli monorepo packages",
+      "matchPackagePatterns": ["^@stricli/"],
+      "groupName": "stricli monorepo",
+      "groupSlug": "stricli-monorepo"
+    },
+    {
+      "description": "Group TypeScript type definitions",
+      "matchPackagePatterns": ["^@types/"],
+      "groupName": "definitelytyped",
+      "groupSlug": "definitelytyped"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -28,12 +28,6 @@
       "matchPackagePatterns": ["^@stricli/"],
       "groupName": "stricli monorepo",
       "groupSlug": "stricli-monorepo"
-    },
-    {
-      "description": "Group TypeScript type definitions",
-      "matchPackagePatterns": ["^@types/"],
-      "groupName": "definitelytyped",
-      "groupSlug": "definitelytyped"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "github>whitesource/merge-confidence:beta"],
+  "extends": ["config:base", "github>whitesource/merge-confidence:beta", "group:monorepos"],
   "automerge": false,
   "automergeType": "branch",
   "major": {
@@ -9,5 +9,13 @@
   "masterIssue": true,
   "prConcurrentLimit": 25,
   "rebaseWhen": "conflicted",
-  "ignoreDeps": []
+  "ignoreDeps": [],
+  "packageRules": [
+    {
+      "description": "Group Kubb monorepo packages",
+      "matchPackagePatterns": ["^@kubb/"],
+      "groupName": "kubb monorepo",
+      "groupSlug": "kubb-monorepo"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Updated `renovate.json` configuration to include grouping for multiple monorepos
- Added `group:monorepos` preset to extend base Renovate config
- Introduced package rules to group all `@kubb/`, `@turf/`, and `@stricli/` packages under single Renovate PRs named respectively

## Changes

### Renovate Configuration
- Extended Renovate config with `group:monorepos` to enable monorepo grouping features
- Added new `packageRules` entries:
  - Matches packages with names starting with `@kubb/`, `@turf/`, and `@stricli/`
  - Groups them into single PRs with names and slugs: `kubb monorepo` (`kubb-monorepo`), `turf monorepo` (`turf-monorepo`), and `stricli monorepo` (`stricli-monorepo`)
- This helps reduce noise from multiple Renovate PRs for related monorepo packages

## Test plan
- Verify Renovate creates grouped PRs for `@kubb/`, `@turf/`, and `@stricli/` packages
- Confirm no regressions in existing Renovate behavior
- Monitor future Renovate runs for proper grouping of monorepo dependencies

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d17763fa-51b6-4e9b-9be4-638f02f7c2f4