### PR TITLE
Update pnpm-lock.yaml to upgrade wrangler and exsolve versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,8 +214,8 @@ importers:
         specifier: 6.2.6
         version: 6.2.6(@types/node@22.17.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
       wrangler:
-        specifier: 4.20.4
-        version: 4.20.4(@cloudflare/workers-types@4.20250614.0)
+        specifier: 4.30.0
+        version: 4.30.0(@cloudflare/workers-types@4.20250614.0)
 
   packages/service:
     dependencies:
@@ -2475,9 +2475,6 @@ packages:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
 
-  exsolve@1.0.5:
-    resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==}
-
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
@@ -4288,16 +4285,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.20.4:
-    resolution: {integrity: sha512-isjMboea3G7/i2kkyTJvpvtRudgYfXZwxDWuMnfcm+v1N2fS31roEG973f3Z0udDCkcaoV3hjRCFvq3vlCk/NA==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@cloudflare/workers-types': ^4.20250617.0
-    peerDependenciesMeta:
-      '@cloudflare/workers-types':
-        optional: true
-
   wrangler@4.30.0:
     resolution: {integrity: sha512-NXJUObuXxgG8/ChQ4yXkWLmDQ5ZcO98gyq1yFKYVntJ884C0IpDQrVnAv2RA0ZEz5eB8zal+4OKnr26P3N7ItA==}
     engines: {node: '>=18.0.0'}
@@ -4596,12 +4583,6 @@ snapshots:
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
       mime: 3.0.0
-
-  '@cloudflare/unenv-preset@2.3.3(unenv@2.0.0-rc.17)(workerd@1.20250617.0)':
-    dependencies:
-      unenv: 2.0.0-rc.17
-    optionalDependencies:
-      workerd: 1.20250617.0
 
   '@cloudflare/unenv-preset@2.3.3(unenv@2.0.0-rc.17)(workerd@1.20250813.0)':
     dependencies:
@@ -6579,8 +6560,6 @@ snapshots:
 
   expect-type@1.2.1: {}
 
-  exsolve@1.0.5: {}
-
   exsolve@1.0.7: {}
 
   ext@1.7.0:
@@ -8260,7 +8239,7 @@ snapshots:
   unenv@2.0.0-rc.17:
     dependencies:
       defu: 6.1.4
-      exsolve: 1.0.5
+      exsolve: 1.0.7
       ohash: 2.0.11
       pathe: 2.0.3
       ufo: 1.6.1
@@ -8498,23 +8477,6 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20250813.0
       '@cloudflare/workerd-linux-arm64': 1.20250813.0
       '@cloudflare/workerd-windows-64': 1.20250813.0
-
-  wrangler@4.20.4(@cloudflare/workers-types@4.20250614.0):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.0
-      '@cloudflare/unenv-preset': 2.3.3(unenv@2.0.0-rc.17)(workerd@1.20250617.0)
-      blake3-wasm: 2.1.5
-      esbuild: 0.25.4
-      miniflare: 4.20250617.2
-      path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.17
-      workerd: 1.20250617.0
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20250614.0
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   wrangler@4.30.0(@cloudflare/workers-types@4.20250614.0):
     dependencies:


### PR DESCRIPTION
## Summary
- Upgrades `wrangler` package from version 4.20.4 to 4.30.0
- Upgrades `exsolve` package from version 1.0.5 to 1.0.7
- Removes outdated package entries and dependencies related to previous versions

## Changes

### Dependency Updates
- Updated `wrangler` specifier and version to 4.30.0 with corresponding integrity and engine requirements
- Updated `exsolve` version to 1.0.7 and removed older 1.0.5 entries
- Cleaned up redundant and obsolete package entries and peer dependencies related to older versions

### Lockfile Maintenance
- Removed unnecessary package snapshots and optional dependencies for cleaner lockfile
- Ensured consistency in package resolutions and integrity hashes

## Test plan
- [x] Verify that the updated `pnpm-lock.yaml` installs dependencies correctly
- [x] Run existing tests to confirm no regressions due to dependency upgrades
- [x] Validate that the application builds and runs with the updated packages
- [x] Confirm no conflicts or warnings during package installation and build process

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f505b003-a91e-4c97-bdc1-6ea962c55b70