### PR TITLE
Update dependencies and lockfile with MUI and React typings upgrades

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         version: 3.16.4(@kubb/react@3.10.15)(ajv@8.17.1)
       '@types/bun':
         specifier: 1.2.20
-        version: 1.2.20(@types/react@19.1.8)
+        version: 1.2.20(@types/react@19.1.10)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -132,8 +132,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       '@mui/material':
-        specifier: 7.1.1
-        version: 7.1.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)
+        specifier: 7.3.1
+        version: 7.3.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)
       '@panva/hkdf':
         specifier: 1.2.1
         version: 1.2.1
@@ -208,11 +208,11 @@ importers:
         specifier: 22.17.2
         version: 22.17.2
       '@types/react':
-        specifier: 19.1.2
-        version: 19.1.2
+        specifier: 19.1.10
+        version: 19.1.10
       '@types/react-dom':
-        specifier: 19.1.2
-        version: 19.1.2(@types/react@19.1.2)
+        specifier: 19.1.7
+        version: 19.1.7(@types/react@19.1.10)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -484,10 +484,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.27.6':
-    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.28.2':
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
@@ -1259,16 +1255,16 @@ packages:
   '@mjackson/node-fetch-server@0.6.1':
     resolution: {integrity: sha512-9ZJnk/DJjt805uv5PPv11haJIW+HHf3YEEyVXv+8iLQxLD/iXA68FH220XoiTPBC4gCg5q+IMadDw8qPqlA5wg==}
 
-  '@mui/core-downloads-tracker@7.1.1':
-    resolution: {integrity: sha512-yBckQs4aQ8mqukLnPC6ivIRv6guhaXi8snVl00VtyojBbm+l6VbVhyTSZ68Abcx7Ah8B+GZhrB7BOli+e+9LkQ==}
+  '@mui/core-downloads-tracker@7.3.1':
+    resolution: {integrity: sha512-+mIK1Z0BhOaQ0vCgOkT1mSrIpEHLo338h4/duuL4TBLXPvUMit732mnwJY3W40Avy30HdeSfwUAAGRkKmwRaEQ==}
 
-  '@mui/material@7.1.1':
-    resolution: {integrity: sha512-mTpdmdZCaHCGOH3SrYM41+XKvNL0iQfM9KlYgpSjgadXx/fEKhhvOktxm8++Xw6FFeOHoOiV+lzOI8X1rsv71A==}
+  '@mui/material@7.3.1':
+    resolution: {integrity: sha512-Xf6Shbo03YmcBedZMwSpEFOwpYDtU7tC+rhAHTrA9FHk0FpsDqiQ9jUa1j/9s3HLs7KWb5mDcGnlwdh9Q9KAag==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
-      '@mui/material-pigment-css': ^7.1.1
+      '@mui/material-pigment-css': ^7.3.1
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1282,8 +1278,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/private-theming@7.1.1':
-    resolution: {integrity: sha512-M8NbLUx+armk2ZuaxBkkMk11ultnWmrPlN0Xe3jUEaBChg/mcxa5HWIWS1EE4DF36WRACaAHVAvyekWlDQf0PQ==}
+  '@mui/private-theming@7.3.1':
+    resolution: {integrity: sha512-WU3YLkKXii/x8ZEKnrLKsPwplCVE11yZxUvlaaZSIzCcI3x2OdFC8eMlNy74hVeUsYQvzzX1Es/k4ARPlFvpPQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1292,8 +1288,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/styled-engine@7.1.1':
-    resolution: {integrity: sha512-R2wpzmSN127j26HrCPYVQ53vvMcT5DaKLoWkrfwUYq3cYytL6TQrCH8JBH3z79B6g4nMZZVoaXrxO757AlShaw==}
+  '@mui/styled-engine@7.3.1':
+    resolution: {integrity: sha512-Nqo6OHjvJpXJ1+9TekTE//+8RybgPQUKwns2Lh0sq+8rJOUSUKS3KALv4InSOdHhIM9Mdi8/L7LTF1/Ky6D6TQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -1305,8 +1301,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/system@7.1.1':
-    resolution: {integrity: sha512-Kj1uhiqnj4Zo7PDjAOghtXJtNABunWvhcRU0O7RQJ7WOxeynoH6wXPcilphV8QTFtkKaip8EiNJRiCD+B3eROA==}
+  '@mui/system@7.3.1':
+    resolution: {integrity: sha512-mIidecvcNVpNJMdPDmCeoSL5zshKBbYPcphjuh6ZMjhybhqhZ4mX6k9zmIWh6XOXcqRQMg5KrcjnO0QstrNj3w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -1321,16 +1317,16 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/types@7.4.3':
-    resolution: {integrity: sha512-2UCEiK29vtiZTeLdS2d4GndBKacVyxGvReznGXGr+CzW/YhjIX+OHUdCIczZjzcRAgKBGmE9zCIgoV9FleuyRQ==}
+  '@mui/types@7.4.5':
+    resolution: {integrity: sha512-ZPwlAOE3e8C0piCKbaabwrqZbW4QvWz0uapVPWya7fYj6PeDkl5sSJmomT7wjOcZGPB48G/a6Ubidqreptxz4g==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/utils@7.1.1':
-    resolution: {integrity: sha512-BkOt2q7MBYl7pweY2JWwfrlahhp+uGLR8S+EhiyRaofeRYUWL2YKbSGQvN4hgSN1i8poN0PaUiii1kEMrchvzg==}
+  '@mui/utils@7.3.1':
+    resolution: {integrity: sha512-/31y4wZqVWa0jzMnzo6JPjxwP6xXy4P3+iLbosFg/mJQowL1KIou0LC+lquWW60FKVbKz5ZUWBg2H3jausa0pw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1785,8 +1781,8 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
-  '@types/react-dom@19.1.2':
-    resolution: {integrity: sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==}
+  '@types/react-dom@19.1.7':
+    resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
     peerDependencies:
       '@types/react': ^19.0.0
 
@@ -1798,11 +1794,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
-  '@types/react@19.1.2':
-    resolution: {integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==}
-
-  '@types/react@19.1.8':
-    resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
+  '@types/react@19.1.10':
+    resolution: {integrity: sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==}
 
   '@types/supercluster@7.1.3':
     resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
@@ -3564,6 +3557,9 @@ packages:
   react-is@19.1.0:
     resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
 
+  react-is@19.1.1:
+    resolution: {integrity: sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==}
+
   react-map-gl@8.0.4:
     resolution: {integrity: sha512-SHdpvFIvswsZBg6BCPcwY/nbKuCo3sJM1Cj7Sd+gA3gFRFOixD+KtZ2XSuUWq2WySL2emYEXEgrLZoXsV4Ut4Q==}
     peerDependencies:
@@ -4559,8 +4555,6 @@ snapshots:
       '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/runtime@7.27.6': {}
-
   '@babel/runtime@7.28.2': {}
 
   '@babel/template@7.27.2':
@@ -4698,7 +4692,7 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)':
+  '@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)':
     dependencies:
       '@babel/runtime': 7.28.2
       '@emotion/babel-plugin': 11.13.5
@@ -4710,7 +4704,7 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 19.2.0-canary-39cad7af-20250411
     optionalDependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.1.10
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -4725,18 +4719,18 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)':
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)':
     dependencies:
       '@babel/runtime': 7.28.2
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
-      '@emotion/react': 11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
+      '@emotion/react': 11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0-canary-39cad7af-20250411)
       '@emotion/utils': 1.4.2
       react: 19.2.0-canary-39cad7af-20250411
     optionalDependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.1.10
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -5257,41 +5251,41 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.6.1': {}
 
-  '@mui/core-downloads-tracker@7.1.1': {}
+  '@mui/core-downloads-tracker@7.3.1': {}
 
-  '@mui/material@7.1.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)':
+  '@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)':
     dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/core-downloads-tracker': 7.1.1
-      '@mui/system': 7.1.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
-      '@mui/types': 7.4.3(@types/react@19.1.2)
-      '@mui/utils': 7.1.1(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
+      '@babel/runtime': 7.28.2
+      '@mui/core-downloads-tracker': 7.3.1
+      '@mui/system': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
+      '@mui/types': 7.4.5(@types/react@19.1.10)
+      '@mui/utils': 7.3.1(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
       '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@19.1.2)
+      '@types/react-transition-group': 4.4.12(@types/react@19.1.10)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 19.2.0-canary-39cad7af-20250411
       react-dom: 19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411)
-      react-is: 19.1.0
+      react-is: 19.1.1
       react-transition-group: 4.4.5(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
-      '@types/react': 19.1.2
+      '@emotion/react': 11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
+      '@types/react': 19.1.10
 
-  '@mui/private-theming@7.1.1(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)':
+  '@mui/private-theming@7.3.1(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)':
     dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/utils': 7.1.1(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
+      '@babel/runtime': 7.28.2
+      '@mui/utils': 7.3.1(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
       prop-types: 15.8.1
       react: 19.2.0-canary-39cad7af-20250411
     optionalDependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.1.10
 
-  '@mui/styled-engine@7.1.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)':
+  '@mui/styled-engine@7.3.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -5299,42 +5293,42 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.0-canary-39cad7af-20250411
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
+      '@emotion/react': 11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
 
-  '@mui/system@7.1.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)':
+  '@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)':
     dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/private-theming': 7.1.1(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
-      '@mui/styled-engine': 7.1.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)
-      '@mui/types': 7.4.3(@types/react@19.1.2)
-      '@mui/utils': 7.1.1(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
+      '@babel/runtime': 7.28.2
+      '@mui/private-theming': 7.3.1(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
+      '@mui/styled-engine': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)
+      '@mui/types': 7.4.5(@types/react@19.1.10)
+      '@mui/utils': 7.3.1(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 19.2.0-canary-39cad7af-20250411
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)
-      '@types/react': 19.1.2
+      '@emotion/react': 11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411))(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)
+      '@types/react': 19.1.10
 
-  '@mui/types@7.4.3(@types/react@19.1.2)':
+  '@mui/types@7.4.5(@types/react@19.1.10)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
     optionalDependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.1.10
 
-  '@mui/utils@7.1.1(@types/react@19.1.2)(react@19.2.0-canary-39cad7af-20250411)':
+  '@mui/utils@7.3.1(@types/react@19.1.10)(react@19.2.0-canary-39cad7af-20250411)':
     dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/types': 7.4.3(@types/react@19.1.2)
+      '@babel/runtime': 7.28.2
+      '@mui/types': 7.4.5(@types/react@19.1.10)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.2.0-canary-39cad7af-20250411
-      react-is: 19.1.0
+      react-is: 19.1.1
     optionalDependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.1.10
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5759,9 +5753,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.6
 
-  '@types/bun@1.2.20(@types/react@19.1.8)':
+  '@types/bun@1.2.20(@types/react@19.1.10)':
     dependencies:
-      bun-types: 1.2.20(@types/react@19.1.8)
+      bun-types: 1.2.20(@types/react@19.1.10)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -5829,23 +5823,19 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
-  '@types/react-dom@19.1.2(@types/react@19.1.2)':
+  '@types/react-dom@19.1.7(@types/react@19.1.10)':
     dependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.1.10
 
   '@types/react-is@19.0.0':
     dependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.1.10
 
-  '@types/react-transition-group@4.4.12(@types/react@19.1.2)':
+  '@types/react-transition-group@4.4.12(@types/react@19.1.10)':
     dependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.1.10
 
-  '@types/react@19.1.2':
-    dependencies:
-      csstype: 3.1.3
-
-  '@types/react@19.1.8':
+  '@types/react@19.1.10':
     dependencies:
       csstype: 3.1.3
 
@@ -6143,10 +6133,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bun-types@1.2.20(@types/react@19.1.8):
+  bun-types@1.2.20(@types/react@19.1.10):
     dependencies:
       '@types/node': 24.3.0
-      '@types/react': 19.1.8
+      '@types/react': 19.1.10
 
   bundle-name@4.1.0:
     dependencies:
@@ -6368,7 +6358,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       csstype: 3.1.3
 
   dotenv@17.2.1: {}
@@ -7664,6 +7654,8 @@ snapshots:
 
   react-is@19.1.0: {}
 
+  react-is@19.1.1: {}
+
   react-map-gl@8.0.4(mapbox-gl@3.12.0)(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411):
     dependencies:
       '@vis.gl/react-mapbox': 8.0.4(mapbox-gl@3.12.0)(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411)
@@ -7691,7 +7683,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.0-canary-39cad7af-20250411(react@19.2.0-canary-39cad7af-20250411))(react@19.2.0-canary-39cad7af-20250411):
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -7804,8 +7796,8 @@ snapshots:
       '@cloudflare/workers-types': 4.20250614.0
       '@puppeteer/browsers': 2.10.5
       '@types/fs-extra': 11.0.4
-      '@types/react': 19.1.2
-      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
       '@types/react-is': 19.0.0
       '@vitejs/plugin-react': 4.5.2(vite@6.2.6(@types/node@22.17.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       chokidar: 3.6.0


### PR DESCRIPTION
## Summary
- Upgrades multiple dependencies in `pnpm-lock.yaml` including MUI packages, React typings, and Babel runtime
- Updates MUI packages from version 7.1.x to 7.3.x and related dependencies
- Bumps React typings from 19.1.2/19.1.8 to 19.1.10 and React-is from 19.1.0 to 19.1.1
- Removes deprecated Babel runtime 7.27.6 and upgrades to 7.28.2

## Changes

### Dependency Updates
- **@mui/material**, **@mui/system**, **@mui/private-theming**, **@mui/styled-engine**, **@mui/utils**, **@mui/types**, and **@mui/core-downloads-tracker** upgraded to 7.3.x series
- **@types/react** upgraded to 19.1.10
- **@types/react-dom** upgraded to 19.1.7
- **react-is** upgraded to 19.1.1
- **@babel/runtime** upgraded to 7.28.2, removing older 7.27.6 version

### Lockfile Adjustments
- Updated integrity hashes and dependency resolutions to reflect new versions
- Cleaned up deprecated or older package versions

## Test plan
- [x] Verify application builds successfully with updated dependencies
- [x] Run existing tests to ensure no regressions
- [x] Confirm UI components using MUI render correctly
- [x] Validate typings compatibility with React 19.1.10

This update ensures the project uses the latest stable versions of key dependencies, improving compatibility and security.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/aa6d7cb6-f01e-45f3-821c-ed293e8500b1